### PR TITLE
Use new socketio format

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,12 +7,12 @@ const prettyBytes = require('pretty-bytes')
 const log = require('single-line-log').stdout
 const pkgJson = require('./package.json')
 
-const argv = minimist(process.argv.slice(2), { string: 'sim'})
+const argv = minimist(process.argv.slice(2), { string: 'sim' })
 const token = argv.token
-const simId = argv.sim
+const simIds = typeof argv.sim === 'string' ? [argv.sim] : argv.sim
 const filename = argv.filename
 const apiUrl = argv.api || 'https://api.onomondo.com'
-const hasAllParams = filename && token && simId
+const hasAllParams = filename && token && simIds && simIds.length
 let capturedPackets = 0
 let capturedBytes = 0
 
@@ -21,9 +21,10 @@ if (!hasAllParams) {
     'Usage:',
     'onomondo-live --token=a1b2c3 --sim=123456789 --filename=output.pcap',
     '',
-    'You need to use the ID of one of your SIMs, and an API token.',
+    'You need to use the ID of one or more of your SIMs, and an API token.',
     'It is also possible to use the token used in the app. Get this by visiting https://app.onomondo.com and look at the network tab in developer tools.',
     '',
+    'If you want to listen to multiple SIMs you can supply multiple --sim params, like this: --sim=111111111 --sim=222222222',
     `Version: ${pkgJson.version}`
   ].join('\n'))
   process.exit(1)
@@ -60,14 +61,14 @@ function connect () {
 
   socket.on('authenticated', () => {
     console.log('Authenticated')
-    socket.emit('attach', simId)
+    simIds.forEach(simId => socket.emit('subscribe:packets', simId))
   })
 
-  socket.on('attached', ({ id, ip }) => {
-    console.log(`Attached. SIM id=${id}. ip=${ip}`)
+  socket.on('subscribed:packets', ({ simId, ip }) => {
+    console.log(`Attached. SIM id=${simId}. ip=${ip}`)
   })
 
-  socket.on('packet', hexString => {
+  socket.on('packets', ({ simId, packet: hexString }) => {
     const timestamp = Date.now()
     const packet = Buffer.from(hexString, 'hex')
 


### PR DESCRIPTION
Updated to use the new format `subscribe:packets` vs `attach`, and `packets` vs `packet`.

Also updated the tool so that you can pass several sim ids