### PR TITLE
Use withCredentials to enable session affinity

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ function run () {
 }
 
 function connect () {
-  const socket = io(apiUrl, { path: '/monitor' })
+  const socket = io(apiUrl, { path: '/monitor', withCredentials: true })
 
   socket.on('connect', () => {
     socket.emit('authenticate', apiKey)


### PR DESCRIPTION
api.onomondo.com requires setting `withCredentials: true` because our load balancers send a `set-cookie` header for session affinity 